### PR TITLE
Fix dialogue modal progression (keep modal open between nodes)

### DIFF
--- a/script.js
+++ b/script.js
@@ -76,7 +76,14 @@ const Modal = {
     this.input.value = "";
     this.actions.innerHTML = "";
   },
-  prompt({ title, message, placeholder = "", onConfirm, showInput = false, options = [] }) {
+  prompt({
+    title,
+    message,
+    placeholder = "",
+    onConfirm,
+    showInput = false,
+    options = []
+  }) {
     this.title.textContent = title;
     this.message.textContent = message;
     this.actions.innerHTML = "";
@@ -95,8 +102,10 @@ const Modal = {
         btn.className = "btn";
         btn.textContent = opt.label;
         btn.addEventListener("click", () => {
-          onConfirm(opt.value ?? opt.label, opt);
-          this.close();
+          const shouldClose = onConfirm(opt.value ?? opt.label, opt);
+          if (shouldClose !== false) {
+            this.close();
+          }
         });
         this.actions.appendChild(btn);
       });
@@ -105,8 +114,10 @@ const Modal = {
       confirmBtn.className = "btn";
       confirmBtn.textContent = "Confirmar";
       confirmBtn.addEventListener("click", () => {
-        onConfirm(this.input.value);
-        this.close();
+        const shouldClose = onConfirm(this.input.value);
+        if (shouldClose !== false) {
+          this.close();
+        }
       });
       this.actions.appendChild(confirmBtn);
     }
@@ -275,9 +286,10 @@ const Game = {
       options: node.options.map((opt) => ({ label: opt.label, value: opt })) ,
       onConfirm: (_, opt) => {
         const option = opt.value;
-        if (option.end) return;
+        if (option.end) return true;
         const nextId = option.next || dialogue.start;
         this.showDialogueNode(dialogue, nextId);
+        return false;
       }
     });
   },


### PR DESCRIPTION
### Motivation
- Fix an issue where selecting a dialogue option immediately closed the modal before the next node was shown, preventing the conversation from advancing.
- Keep the modal overlay open while navigating between dialogue nodes so the UI doesn't flicker or hide content unexpectedly.
- Make modal behavior consistent for both option-based prompts and confirm/input prompts.

### Description
- Updated `Modal.prompt` in `script.js` to inspect the return value of `onConfirm` and only call `this.close()` if the handler does not return `false`.
- Adjusted option button and confirm handlers to respect the `onConfirm` `shouldClose` signal instead of always closing the modal.
- Modified `Game.showDialogueNode` so it returns `true` when an option ends the conversation and `false` when it advances to the next node, allowing the modal to remain open between nodes.
- Minor reformatting of the `prompt` parameter list for readability in `script.js`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69452a76c5b883219bc1cf35eea25b69)